### PR TITLE
Fix Illegal string offset issue

### DIFF
--- a/lib/Spyc/spyc.php
+++ b/lib/Spyc/spyc.php
@@ -772,6 +772,7 @@ class Spyc {
 
       $_arr = array_merge ($_arr, $value);
     } else if ($key || $key === '' || $key === '0') {
+      if (!is_array ($_arr)) { $_arr = array (); }
       $_arr[$key] = $value;
     } else {
       if (!is_array ($_arr)) { $_arr = array ($value); $key = 0; }


### PR DESCRIPTION
Error was:
```
Fatal error: Uncaught Exception: Warning: Illegal string offset 'app'  in /var/www/html/vendor/ecomdev/ecomdev_phpunit/lib/Spyc/spyc.php on line 775 in /var/www/html/app/code/core/Mage/Core/functions.php:232
```
Solution was "stolen" here:
https://github.com/EcomDev/EcomDev_PHPUnit/pull/285